### PR TITLE
[FIX] PHP7.4 compatibility

### DIFF
--- a/classes/class.MetaBlockGUI.php
+++ b/classes/class.MetaBlockGUI.php
@@ -9,7 +9,7 @@ class MetaBlockGUI extends BlockGUI
     /**
      * @var MetaBlock
      */
-    protected \ilub\plugin\SelfEvaluation\Block\Matrix\QuestionBlock|MetaBlock $object;
+    protected $object;
 
     public function __construct(
         ilDBInterface $db,

--- a/classes/class.PlayerGUI.php
+++ b/classes/class.PlayerGUI.php
@@ -29,7 +29,10 @@ class PlayerGUI
     protected ilSelfEvaluationPlugin $plugin;
     protected ilDBInterface $db;
     protected Identity $identity;
-    protected Dataset|bool $dataset;
+    /**
+     * @var \ilub\plugin\SelfEvaluation\Dataset\Dataset|bool
+     */
+    protected $dataset;
     protected WrapperFactory $http;
     protected Factory $refinery;
 

--- a/classes/class.QuestionBlockGUI.php
+++ b/classes/class.QuestionBlockGUI.php
@@ -6,7 +6,10 @@ use ilub\plugin\SelfEvaluation\Block\Matrix\QuestionBlock;
 
 class QuestionBlockGUI extends BlockGUI
 {
-    protected QuestionBlock|\ilub\plugin\SelfEvaluation\Block\Meta\MetaBlock $object;
+    /**
+     * @var \ilub\plugin\SelfEvaluation\Block\Matrix\QuestionBlock|\ilub\plugin\SelfEvaluation\Block\Meta\MetaBlock
+     */
+    protected $object;
 
     public function __construct(
         ilDBInterface $db,

--- a/src/Block/BlockGUI.php
+++ b/src/Block/BlockGUI.php
@@ -34,7 +34,10 @@ abstract class BlockGUI
 
     protected ilSelfEvaluationPlugin $plugin;
 
-    protected QuestionBlock|Metablock $object;
+    /**
+     * @var \ilub\plugin\SelfEvaluation\Block\Matrix\QuestionBlock|Metablock
+     */
+    protected $object;
 
     public function __construct(
         ilDBInterface $db,

--- a/src/Dataset/Dataset.php
+++ b/src/Dataset/Dataset.php
@@ -156,10 +156,10 @@ class Dataset implements hasDBFields
 
     protected function determineQuestionType(string $postvar_key): string
     {
-        if (str_starts_with($postvar_key, Question::POSTVAR_PREFIX)) {
+        if (strncmp($postvar_key, Question::POSTVAR_PREFIX, strlen(Question::POSTVAR_PREFIX)) === 0) {
             return Data::QUESTION_TYPE;
         }
-        if (str_starts_with($postvar_key, MetaQuestion::POSTVAR_PREFIX)) {
+        if (strncmp($postvar_key, MetaQuestion::POSTVAR_PREFIX, strlen(MetaQuestion::POSTVAR_PREFIX)) === 0) {
             return Data::META_QUESTION_TYPE;
         }
         return "";

--- a/src/Player/PlayerFormContainer.php
+++ b/src/Player/PlayerFormContainer.php
@@ -29,7 +29,7 @@ class PlayerFormContainer extends ilPropertyFormGUI
     /**
      * @var ilGlobalTemplateInterface
      */
-    protected ilGlobalTemplateInterface|null $global_tpl;
+    protected $global_tpl;
 
     /**
      * @var ilRepositoryObjectPlugin

--- a/src/Player/PlayerFormContainer.php
+++ b/src/Player/PlayerFormContainer.php
@@ -25,11 +25,7 @@ class PlayerFormContainer extends ilPropertyFormGUI
      * @var int
      */
     protected $question_field_size = 6;
-
-    /**
-     * @var ilGlobalTemplateInterface
-     */
-    protected $global_tpl;
+    
 
     /**
      * @var ilRepositoryObjectPlugin

--- a/src/UIHelper/MatrixHeaderGUI.php
+++ b/src/UIHelper/MatrixHeaderGUI.php
@@ -89,7 +89,7 @@ class MatrixHeaderGUI extends ilSubEnabledFormPropertyGUI
         $this->parentform = $parentform;
     }
 
-    public function getParentform(): \ilPropertyFormGUI|null
+    public function getParentform(): ?\ilPropertyFormGUI
     {
         return $this->parentform;
     }


### PR DESCRIPTION
With our plugins, we always try to support the PHP versions that are also supported by the compatible ILIAS versions. we are currently using SelfEvaluation on an installation that uses ILIAS 8 with PHP 7.4. this is missing because the plugin already uses PHP 8 syntax. This PR would restore 7.4 compatibility.

up to you, if you want to do the same, I understand of course, if you already want to use newer syntax