### PR TITLE
[FIX] SUPPORT-17784: Show icon for incomplete dataset in results table

### DIFF
--- a/src/Dataset/DatasetTableGUI.php
+++ b/src/Dataset/DatasetTableGUI.php
@@ -63,8 +63,7 @@ class DatasetTableGUI extends ilTable2GUI
         $this->tpl->setVariable("ID", $obj->getId());
         $this->tpl->setVariable(
             'COMPLETE',
-            $obj->isComplete() ? ilUtil::getImagePath('standard/icon_ok.svg') : $this->plugin->getDirectory(
-            ) . '/templates/images/empty.png'
+            ilUtil::getImagePath($obj->isComplete() ? 'standard/icon_ok.svg' : 'standard/icon_not_ok.svg')
         );
         $this->tpl->setVariable('DATE', date('d.m.Y - H:i:s', $obj->getCreationDate()));
         $this->tpl->setVariable('EDIT_LINK', $this->ctrl->getLinkTargetByClass(DatasetGUI::class, 'show'));


### PR DESCRIPTION
Replace the broken-image placeholder shown in the "Abgeschlossen" column of the dataset results table with the standard ILIAS icon. The previous code used $plugin->getDirectory() (absolute filesystem path) as an <img> src, which the browser cannot resolve, so incomplete rows rendered with the broken-image icon instead of empty.png.

Use ilUtil::getImagePath() for both states and switch the incomplete state to standard/icon_not_ok.svg so users see a clear cross/check pair.